### PR TITLE
fix: restore WASD movement while gossip dialog is open

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -5,4 +5,13 @@
     <Binding name="DIALOGUI_DECLINE_OR_CANCEL" key1="ESCAPE">
         DialogUI_DeclineOrCancel();
     </Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_1">DialogUI_GossipOption(1)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_2">DialogUI_GossipOption(2)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_3">DialogUI_GossipOption(3)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_4">DialogUI_GossipOption(4)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_5">DialogUI_GossipOption(5)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_6">DialogUI_GossipOption(6)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_7">DialogUI_GossipOption(7)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_8">DialogUI_GossipOption(8)</Binding>
+    <Binding name="DIALOGUI_GOSSIP_OPTION_9">DialogUI_GossipOption(9)</Binding>
 </Bindings>

--- a/src/bindings.lua
+++ b/src/bindings.lua
@@ -2,6 +2,15 @@
 BINDING_HEADER_DIALOGUI = "DialogUI";
 BINDING_NAME_DIALOGUI_ACCEPT_OR_COMPLETE = "Accept / Complete / Select First";
 BINDING_NAME_DIALOGUI_DECLINE_OR_CANCEL = "Decline / Cancel / Close";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_1 = "Gossip Option 1";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_2 = "Gossip Option 2";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_3 = "Gossip Option 3";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_4 = "Gossip Option 4";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_5 = "Gossip Option 5";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_6 = "Gossip Option 6";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_7 = "Gossip Option 7";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_8 = "Gossip Option 8";
+BINDING_NAME_DIALOGUI_GOSSIP_OPTION_9 = "Gossip Option 9";
 
 DIALOGUI_ACCEPT_BINDING = "DIALOGUI_ACCEPT_OR_COMPLETE";
 DIALOGUI_DECLINE_BINDING = "DIALOGUI_DECLINE_OR_CANCEL";
@@ -197,5 +206,34 @@ function DialogUI_DeclineOrCancel()
 
     if (DGossipFrame and DGossipFrame:IsVisible()) then
         CloseGossip();
+    end
+end
+
+function DialogUI_GossipOption(n)
+    if (DGossipFrame and DGossipFrame:IsVisible()) then
+        DGossipSelectOption(n);
+    end
+end
+
+local savedNumberBindings = {};
+local gossipNumberKeysActive = false;
+
+function DialogUI_GossipBindNumberKeys()
+    if gossipNumberKeysActive then return; end
+    gossipNumberKeysActive = true;
+    for i = 1, 9 do
+        local key = tostring(i);
+        savedNumberBindings[i] = GetBindingAction(key);
+        SetBinding(key, "DIALOGUI_GOSSIP_OPTION_" .. i);
+    end
+end
+
+function DialogUI_GossipRestoreNumberKeys()
+    if not gossipNumberKeysActive then return; end
+    gossipNumberKeysActive = false;
+    for i = 1, 9 do
+        local key = tostring(i);
+        SetBinding(key, savedNumberBindings[i]);
+        savedNumberBindings[i] = nil;
     end
 end

--- a/src/frames/gossipFrame/gossip.frame.lua
+++ b/src/frames/gossipFrame/gossip.frame.lua
@@ -29,16 +29,6 @@ function DGossipFrame_OnLoad()
     HideDefaultFrames()
     this:RegisterEvent("GOSSIP_SHOW");
     this:RegisterEvent("GOSSIP_CLOSED");
-    
-    -- Create simplified key handler frame
-    if not DGossipKeyFrame then
-        CreateFrame("Frame", "DGossipKeyFrame", UIParent)
-        DGossipKeyFrame:SetScript("OnKeyDown", DGossipFrame_OnKeyDown)
-        DGossipKeyFrame:EnableKeyboard(false) -- Start disabled
-        DGossipKeyFrame:SetToplevel(true)
-        DGossipKeyFrame:SetAllPoints(UIParent)
-        DGossipKeyFrame:SetFrameStrata("TOOLTIP")
-    end
 end
 
 function DGossipFrame_OnEvent()
@@ -52,50 +42,11 @@ function DGossipFrame_OnEvent()
         end
         DGossipFrameUpdate();
         DialogUI_UpdateKeyBindingLabels();
-        -- Enable key capture when gossip frame is shown
-        DGossipKeyFrame:EnableKeyboard(true)
+        DialogUI_GossipBindNumberKeys();
     elseif (event == "GOSSIP_CLOSED") then
+        DialogUI_GossipRestoreNumberKeys();
         HideUIPanel(DGossipFrame);
-        -- Disable key capture when gossip frame is closed
-        DGossipKeyFrame:EnableKeyboard(false)
     end
-end
-
--- Simplified key handler - only handles what we need
-function DGossipFrame_OnKeyDown()
-    local key = arg1
-    
-    if DialogUI_IsBindingKey(DIALOGUI_DECLINE_BINDING, key, "ESCAPE") then
-        CloseGossip()
-        return
-    end
-    
-    if DialogUI_IsBindingKey(DIALOGUI_ACCEPT_BINDING, key, "SPACE") then
-        DGossipSelectOption(1)
-        return
-    end
-    
-    -- Handle number keys 1-9 for gossip options
-    if key >= "1" and key <= "9" then
-        local buttonIndex = tonumber(key)
-        DGossipSelectOption(buttonIndex)
-        return
-    end
-    
-    -- For all other keys, let the game handle them normally
-    -- We do this by temporarily disabling our keyboard capture
-    DGossipKeyFrame:EnableKeyboard(false)
-    
-    -- Re-enable after a brief moment using a simple timer
-    local reEnableTime = GetTime() + 0.05
-    DGossipKeyFrame:SetScript("OnUpdate", function()
-        if GetTime() >= reEnableTime then
-            if DGossipFrame:IsVisible() then
-                DGossipKeyFrame:EnableKeyboard(true)
-            end
-            DGossipKeyFrame:SetScript("OnUpdate", nil)
-        end
-    end)
 end
 
 -- Simplified option selection function


### PR DESCRIPTION
## Summary

- `DGossipKeyFrame` was a full-screen frame at `TOOLTIP` strata with `SetToplevel(true)`, making it an exclusive keyboard sink that consumed all input — including WASD movement keys
- The 50ms disable-then-reenable workaround couldn't retroactively forward already-consumed events to WoW's movement system
- Fix: drop all frame keyboard capture and use dynamic key rebinding instead — on `GOSSIP_SHOW`, temporarily rebind 1-9 to `DIALOGUI_GOSSIP_OPTION_1-9`; on `GOSSIP_CLOSED`, restore original bindings
- A guard flag prevents double-restore since `GOSSIP_CLOSED` can fire twice (once from the game, once via `OnHide` → `CloseGossip()`)
- SPACE and ESC continue to work through the existing `Bindings.xml` entries without any frame keyboard capture

## Test plan

- [x] SPACE selects the first gossip option
- [x] WASD movement works while the gossip dialog is open
- [x] ESC closes the gossip dialog
- [x] Number keys 1–9 select the correct gossip option
- [x] After closing gossip, number keys 1–9 return to their original bindings (e.g. action bar slots)